### PR TITLE
Refactor keyboard layout and props

### DIFF
--- a/components/CalcKeyboard.js
+++ b/components/CalcKeyboard.js
@@ -40,7 +40,12 @@ const styles = StyleSheet.create({
 });
 
 export const CalcKeyboard = (props) => {
-  const { numericBtnFn, operatorBtnFn, clearBtnFn } = props;
+  const {
+    numericBtnFn,
+    operatorBtnFn,
+    equalBtnFn,
+    clearBtnFn,
+  } = props;
 
   const keyboardButtons = [
     [
@@ -64,7 +69,7 @@ export const CalcKeyboard = (props) => {
     [
       { title: 'CLR', buttonFn: clearBtnFn },
       { title: '0', buttonFn: numericBtnFn },
-      { title: '=', buttonFn: operatorBtnFn },
+      { title: '=', buttonFn: equalBtnFn },
       { title: '/', buttonFn: operatorBtnFn },
     ],
   ];
@@ -130,6 +135,12 @@ CalcKeyboard.propTypes = {
    */
   operatorBtnFn: PropTypes.func,
   /**
+   * equalBtnFn
+   *
+   * Function executed when the '=' button is pressed.
+   */
+  equalBtnFn: PropTypes.func,
+  /**
    * clearBtnFn
    *
    * Function executed when the "clear" button is pressed.
@@ -141,5 +152,6 @@ CalcKeyboard.propTypes = {
 CalcKeyboard.defaultProps = {
   numericBtnFn: () => {},
   operatorBtnFn: () => {},
+  equalBtnFn: () => {},
   clearBtnFn: () => {},
 };

--- a/components/CalcKeyboard.js
+++ b/components/CalcKeyboard.js
@@ -21,7 +21,7 @@ const styles = StyleSheet.create({
   buttonRow: {
     flexDirection: 'row',
     width: '100%',
-    height: '24%',
+    height: '20%',
     justifyContent: 'space-between',
   },
   button: {
@@ -29,6 +29,15 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.calcButton,
     justifyContent: 'center',
     alignItems: 'center',
+    borderWidth: 0.5,
+    borderColor: Colors.white,
+    borderRadius: 10,
+  },
+  clearButton: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.calcButton,
+    width: '100%',
     borderWidth: 0.5,
     borderColor: Colors.white,
     borderRadius: 10,
@@ -118,6 +127,7 @@ export const CalcKeyboard = (props) => {
       <TouchableOpacity
         onPress={clearBtnFn}
         activeOpacity={0.9}
+        style={styles.clearButton}
       >
         <Text style={styles.buttonText}>CLEAR</Text>
       </TouchableOpacity>

--- a/components/CalcKeyboard.js
+++ b/components/CalcKeyboard.js
@@ -67,7 +67,7 @@ export const CalcKeyboard = (props) => {
       { title: 'x', buttonFn: operatorBtnFn },
     ],
     [
-      { title: 'CLR', buttonFn: clearBtnFn },
+      { title: '.', buttonFn: numericBtnFn },
       { title: '0', buttonFn: numericBtnFn },
       { title: '=', buttonFn: equalBtnFn },
       { title: '/', buttonFn: operatorBtnFn },
@@ -115,6 +115,12 @@ export const CalcKeyboard = (props) => {
   return (
     <View style={styles.container}>
       {createKeyboard(keyboardButtons)}
+      <TouchableOpacity
+        onPress={clearBtnFn}
+        activeOpacity={0.9}
+      >
+        <Text style={styles.buttonText}>CLEAR</Text>
+      </TouchableOpacity>
     </View>
   );
 };

--- a/components/CalcKeyboard.test.js
+++ b/components/CalcKeyboard.test.js
@@ -10,7 +10,7 @@ describe('CalcKeyboard Component', () => {
     testFuncs = render(<CalcKeyboard />);
   });
 
-  test.each(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '+', '-', 'x', '/', 'CLR', '='])(
+  test.each(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '+', '-', 'x', '/', 'CLEAR', '.', '='])(
     'display button %s',
     (i) => {
       expect(testFuncs.getByText(i)).toBeTruthy();


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/22417165/75120483-f844c500-566a-11ea-89a9-42027214bec2.png)


New props:

-  `equalBtnFn`: executed when the "=" button is pressed. Originally, this event would be handled by the `operatorBtnFn`, but the behavior expected from the "=" button is different enough to warrant a new props.

Modifications in layout:

- '.' button: to allow user to input decimals.

- New row: the '.' button takes the place of the old 'CLR' button next to zero, while the new 'CLEAR' button occupies a new row at the bottom of the keyboard.